### PR TITLE
[ BE ] comment API에서 update와 delete 로직 및 테스트코드 수정

### DIFF
--- a/backend/src/controller/__test__/comment.test.js
+++ b/backend/src/controller/__test__/comment.test.js
@@ -67,31 +67,31 @@ describe('create comment Controller 테스트', () => {
 });
 
 describe('remove comment Controller 테스트', () => {
-  const removeData = { commentId: 1 };
+  const removeParams = { id: 1 };
   beforeEach(() => {
-    req.body = removeData;
+    req.params = removeParams;
   });
 
   it('함수인가', () => {
-    commentService.remove.mockReturnValue(removeData);
+    commentService.remove.mockReturnValue(true);
     expect(typeof commentController.remove).toBe('function');
   });
 
   it('service에 data가 들어가는가', async () => {
-    commentService.remove.mockReturnValue(removeData);
+    commentService.remove.mockReturnValue(true);
     await commentController.remove(req, res);
-    expect(commentService.remove).toBeCalledWith(removeData);
+    expect(commentService.remove).toBeCalledWith(removeParams);
   });
 
   it('성공 시 200응답이 오는가', async () => {
-    commentService.remove.mockReturnValue(removeData);
+    commentService.remove.mockReturnValue(true);
     await commentController.remove(req, res);
     expect(res.statusCode).toBe(200);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
   it('json을 리턴하는가', async () => {
-    commentService.remove.mockReturnValue(removeData);
+    commentService.remove.mockReturnValue(true);
     await commentController.remove(req, res);
     expect(res._isJSON()).toBeTruthy();
   });
@@ -114,31 +114,37 @@ describe('remove comment Controller 테스트', () => {
 });
 
 describe('update comment Controller 테스트', () => {
-  const updateData = { commentId: 1, content: 'byeworld' };
+  const updateData = { content: 'byeworld' };
+  const updateParams = { id: 1 };
+
   beforeEach(() => {
     req.body = updateData;
+    req.params = updateParams;
   });
 
   it('함수인가', () => {
-    commentService.update.mockReturnValue(1);
+    commentService.update.mockReturnValue(true);
     expect(typeof commentController.update).toBe('function');
   });
 
   it('service에 data가 들어가는가', async () => {
-    commentService.update.mockReturnValue(1);
+    commentService.update.mockReturnValue(true);
     await commentController.update(req, res);
-    expect(commentService.update).toBeCalledWith(updateData);
+    expect(commentService.update).toBeCalledWith({
+      ...updateData,
+      ...updateParams,
+    });
   });
 
   it('성공 시 200응답이 오는가', async () => {
-    commentService.update.mockReturnValue(1);
+    commentService.update.mockReturnValue(true);
     await commentController.update(req, res);
     expect(res.statusCode).toBe(200);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
   it('json을 리턴하는가', async () => {
-    commentService.update.mockReturnValue(1);
+    commentService.update.mockReturnValue(true);
     await commentController.update(req, res);
     expect(res._isJSON()).toBeTruthy();
   });

--- a/backend/src/controller/comment.js
+++ b/backend/src/controller/comment.js
@@ -16,7 +16,7 @@ module.exports = {
 
   remove: async (req, res) => {
     try {
-      const result = await comment.remove(req.body);
+      const result = await comment.remove(req.params);
 
       if (!result.error) {
         return res.status(200).json(result);
@@ -29,7 +29,7 @@ module.exports = {
 
   update: async (req, res) => {
     try {
-      const result = await comment.update(req.body);
+      const result = await comment.update({ ...req.body, ...req.params });
 
       if (!result.error) {
         return res.status(200).json(result[0]);

--- a/backend/src/model/__test__/label.test.js
+++ b/backend/src/model/__test__/label.test.js
@@ -20,7 +20,7 @@ describe('Label모델 테스트', () => {
         primaryKey: true,
       },
       color: {
-        type: DataTypes.MEDIUMINT,
+        type: DataTypes.STRING(7),
         allowNull: false,
       },
       title: {

--- a/backend/src/routes/comment.js
+++ b/backend/src/routes/comment.js
@@ -8,8 +8,8 @@ const router = express.Router();
 
 router.post('/', comment.create);
 
-router.delete('/', comment.remove);
+router.delete('/:id', comment.remove);
 
-router.put('/', comment.update);
+router.put('/:id', comment.update);
 
 module.exports = router;

--- a/backend/src/service/__test__/comment.test.js
+++ b/backend/src/service/__test__/comment.test.js
@@ -36,16 +36,21 @@ describe('remove comment service 테스트', () => {
     expect(typeof commentService.remove).toBe('function');
   });
 
-  it('리턴 타입이 number인가', async () => {
+  it('리턴 타입이 boolean인가', async () => {
     Comment.destroy.mockReturnValue(1);
     const result = await commentService.remove(commentResult);
-    expect(typeof result).toBe('number');
+    expect(typeof result).toBe('boolean');
   });
 
   it('잘못된 정보는 에러를 반환하는가', async () => {
-    Comment.destroy.mockReturnValue(1);
     const result = await commentService.remove({});
     expect(result).toEqual({ error: '정보가 부족합니다' });
+  });
+
+  it('DB에 존재하지 않는 id라면', async () => {
+    Comment.destroy.mockReturnValue(0);
+    const result = await commentService.remove(commentResult);
+    expect(result).toEqual({ error: '존재하지 않는 댓글입니다' });
   });
 });
 
@@ -56,15 +61,20 @@ describe('update comment service 테스트', () => {
     expect(typeof commentService.update).toBe('function');
   });
 
-  it('리턴 타입이 number인가', async () => {
-    Comment.update.mockReturnValue(1);
+  it('리턴 타입이 boolean인가', async () => {
+    Comment.update.mockReturnValue([1]);
     const result = await commentService.update(commentResult);
-    expect(typeof result).toBe('number');
+    expect(typeof result).toBe('boolean');
   });
 
   it('잘못된 정보는 에러를 반환하는가', async () => {
-    Comment.update.mockReturnValue(1);
     const result = await commentService.update({});
     expect(result).toEqual({ error: '정보가 부족합니다' });
+  });
+
+  it('DB에 존재하지 않는 id라면', async () => {
+    Comment.update.mockReturnValue([0]);
+    const result = await commentService.update(commentResult);
+    expect(result).toEqual({ error: '존재하지 않는 댓글입니다' });
   });
 });

--- a/backend/src/service/__test__/comment.test.js
+++ b/backend/src/service/__test__/comment.test.js
@@ -30,7 +30,7 @@ describe('create comment service 테스트', () => {
 });
 
 describe('remove comment service 테스트', () => {
-  const commentResult = { commentId: 1 };
+  const commentResult = { id: 1 };
 
   it('함수인가', () => {
     expect(typeof commentService.remove).toBe('function');
@@ -55,7 +55,7 @@ describe('remove comment service 테스트', () => {
 });
 
 describe('update comment service 테스트', () => {
-  const commentResult = { commentId: 1 };
+  const commentResult = { id: 1 };
 
   it('함수인가', () => {
     expect(typeof commentService.update).toBe('function');

--- a/backend/src/service/comment.js
+++ b/backend/src/service/comment.js
@@ -15,12 +15,12 @@ module.exports = {
     return comment;
   },
 
-  remove: async ({ commentId }) => {
-    if (!commentId) {
+  remove: async ({ id }) => {
+    if (!id) {
       return { error: '정보가 부족합니다' };
     }
 
-    const comment = await Comment.destroy({ where: { id: commentId } });
+    const comment = await Comment.destroy({ where: { id } });
 
     if (comment) {
       return true;
@@ -28,15 +28,12 @@ module.exports = {
     return { error: '존재하지 않는 댓글입니다' };
   },
 
-  update: async ({ commentId, content }) => {
-    if (!commentId) {
+  update: async ({ id, content }) => {
+    if (!id) {
       return { error: '정보가 부족합니다' };
     }
 
-    const [comment] = await Comment.update(
-      { content },
-      { where: { id: commentId } }
-    );
+    const [comment] = await Comment.update({ content }, { where: { id } });
 
     if (comment) {
       return true;

--- a/backend/src/service/comment.js
+++ b/backend/src/service/comment.js
@@ -22,7 +22,10 @@ module.exports = {
 
     const comment = await Comment.destroy({ where: { id: commentId } });
 
-    return comment;
+    if (comment) {
+      return true;
+    }
+    return { error: '존재하지 않는 댓글입니다' };
   },
 
   update: async ({ commentId, content }) => {
@@ -30,11 +33,14 @@ module.exports = {
       return { error: '정보가 부족합니다' };
     }
 
-    const comment = await Comment.update(
+    const [comment] = await Comment.update(
       { content },
       { where: { id: commentId } }
     );
 
-    return comment;
+    if (comment) {
+      return true;
+    }
+    return { error: '존재하지 않는 댓글입니다' };
   },
 };


### PR DESCRIPTION
## 상세사항
- update / delete할 때 해당 댓글의 id를 restAPI를 위해서 params로 전달
- 그에 따라서 controller와 service, routes로직 수정 및 테스트코드 수정

## 기타사항
- label model의 테스트 코드에서 schema 업데이트