### PR TITLE
[BE] 컨트롤러 로직 변경으로 인한 테스트 코드 수정

### DIFF
--- a/backend/src/controller/__test__/comment.test.js
+++ b/backend/src/controller/__test__/comment.test.js
@@ -53,11 +53,11 @@ describe('create comment Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     commentService.create.mockReturnValue(errorMessage);
     await commentController.create(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -100,11 +100,11 @@ describe('remove comment Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     commentService.remove.mockReturnValue(errorMessage);
     await commentController.remove(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -153,11 +153,11 @@ describe('update comment Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     commentService.update.mockReturnValue(errorMessage);
     await commentController.update(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -197,11 +197,11 @@ describe('read comment Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     commentService.read.mockReturnValue(errorMessage);
     await commentController.read(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 

--- a/backend/src/controller/__test__/image.test.js
+++ b/backend/src/controller/__test__/image.test.js
@@ -14,10 +14,9 @@ beforeEach(() => {
 });
 
 describe('upload image Controller 테스트', () => {
-  const newImage = 'it is image file';
-  const resulted = 'image url';
+  const resulted = 'imageurl.jpg';
   beforeEach(() => {
-    req.file = newImage;
+    req.file = resulted;
   });
 
   it('함수인가', () => {
@@ -28,12 +27,12 @@ describe('upload image Controller 테스트', () => {
   it('service에 newimage가 들어가는가', async () => {
     imageService.upload.mockReturnValue(resulted);
     await imageController.upload(req, res);
-    expect(imageService.upload).toBeCalledWith(newImage);
+    expect(imageService.upload).toBeCalledWith(resulted);
   });
 
-  it('성공 시 201응답이 오는가', async () => {
+  it('성공 시 201응답이 오는가', () => {
     imageService.upload.mockReturnValue(resulted);
-    await imageController.upload(req, res);
+    imageController.upload(req, res);
     expect(res.statusCode).toBe(201);
     expect(res._isEndCalled()).toBeTruthy();
   });
@@ -44,11 +43,11 @@ describe('upload image Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 401응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     imageService.upload.mockReturnValue(errorMessage);
     await imageController.upload(req, res);
-    expect(res.statusCode).toBe(401);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 });

--- a/backend/src/controller/__test__/issue.test.js
+++ b/backend/src/controller/__test__/issue.test.js
@@ -80,11 +80,11 @@ describe('create issue Controller 테스트', () => {
     expect(res._isEndCalled()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     issueService.create.mockReturnValue(errorMessage);
     await issueController.create(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -115,11 +115,11 @@ describe('read issue Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     issueService.read.mockReturnValue(errorMessage);
     await issueController.read(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -154,11 +154,11 @@ describe('remove issue Controller 테스트', () => {
     expect(res._isEndCalled()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     issueService.remove.mockReturnValue(errorMessage);
     await issueController.remove(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 

--- a/backend/src/controller/__test__/label.test.js
+++ b/backend/src/controller/__test__/label.test.js
@@ -56,11 +56,11 @@ describe('Label Controller 테스트', () => {
       expect(res._isJSON()).toBeTruthy();
     });
 
-    it('에러가 나면 403응답이 오는가', async () => {
+    it('에러가 나면 400응답이 오는가', async () => {
       const errorMessage = { error: 'Error Message' };
       labelService.create.mockReturnValue(errorMessage);
       await labelController.create(req, res);
-      expect(res.statusCode).toBe(403);
+      expect(res.statusCode).toBe(400);
       expect(res._isEndCalled()).toBeTruthy();
     });
     it('서버에서 에러가 나면 500응답이 오는가', async () => {
@@ -89,11 +89,11 @@ describe('Label Controller 테스트', () => {
       expect(res._isJSON()).toBeTruthy();
     });
 
-    it('에러가 나면 403응답이 오는가', async () => {
+    it('에러가 나면 400응답이 오는가', async () => {
       const errorMessage = { error: 'Error Message' };
       labelService.read.mockReturnValue(errorMessage);
       await labelController.read(req, res);
-      expect(res.statusCode).toBe(403);
+      expect(res.statusCode).toBe(400);
       expect(res._isEndCalled()).toBeTruthy();
     });
 
@@ -127,11 +127,11 @@ describe('Label Controller 테스트', () => {
       expect(res._isEndCalled()).toBeTruthy();
     });
 
-    it('에러가 나면 403응답이 오는가', async () => {
+    it('에러가 나면 400응답이 오는가', async () => {
       const errorMessage = { error: 'Error Message' };
       labelService.update.mockReturnValue(errorMessage);
       await labelController.update(req, res);
-      expect(res.statusCode).toBe(403);
+      expect(res.statusCode).toBe(400);
       expect(res._isEndCalled()).toBeTruthy();
     });
 
@@ -164,11 +164,11 @@ describe('Label Controller 테스트', () => {
       expect(res._isEndCalled()).toBeTruthy();
     });
 
-    it('에러가 나면 403응답이 오는가', async () => {
+    it('에러가 나면 400응답이 오는가', async () => {
       const errorMessage = { error: 'Error Message' };
       labelService.remove.mockReturnValue(errorMessage);
       await labelController.remove(req, res);
-      expect(res.statusCode).toBe(403);
+      expect(res.statusCode).toBe(400);
       expect(res._isEndCalled()).toBeTruthy();
     });
 

--- a/backend/src/controller/__test__/milestone.test.js
+++ b/backend/src/controller/__test__/milestone.test.js
@@ -53,11 +53,11 @@ describe('create milestone Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     milestoneService.create.mockReturnValue(errorMessage);
     await milestoneController.create(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -85,7 +85,10 @@ describe('update milestone Controller 테스트', () => {
   it('service에 newmilestone가 들어가는가', async () => {
     milestoneService.update.mockReturnValue(newmilestone);
     await milestoneController.update(req, res);
-    expect(milestoneService.update).toBeCalledWith(userParams, newmilestone);
+    expect(milestoneService.update).toBeCalledWith({
+      ...userParams,
+      ...newmilestone,
+    });
   });
 
   it('성공 시 200응답이 오는가', async () => {
@@ -101,11 +104,11 @@ describe('update milestone Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     milestoneService.update.mockReturnValue(errorMessage);
     await milestoneController.update(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -148,11 +151,11 @@ describe('remove milestone Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     milestoneService.remove.mockReturnValue(errorMessage);
     await milestoneController.remove(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -194,11 +197,11 @@ describe('read milestone Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     milestoneService.read.mockReturnValue(errorMessage);
     await milestoneController.read(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 

--- a/backend/src/controller/__test__/user.test.js
+++ b/backend/src/controller/__test__/user.test.js
@@ -48,11 +48,11 @@ describe('gitHubLogin user Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     userService.gitHubLogin.mockReturnValue(errorMessage);
     await userController.gitHubLogin(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 });
@@ -88,11 +88,11 @@ describe('iOSAppleLogin user Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     userService.iOSAppleLogin.mockReturnValue(errorMessage);
     await userController.iOSAppleLogin(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 });
@@ -118,11 +118,11 @@ describe('getUsers user Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     userService.getUsers.mockReturnValue(errorMessage);
     await userController.getUsers(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 });
@@ -145,10 +145,10 @@ describe('iOSGithubLogin user Controller 테스트', () => {
     expect(userService.iOSGithubLogin).toBeCalledWith(newUser);
   });
 
-  it('성공 시 201응답이 오는가', async () => {
+  it('성공 시 200응답이 오는가', async () => {
     userService.iOSGithubLogin.mockReturnValue(resulted);
     await userController.iOSGitHubLogin(req, res);
-    expect(res.statusCode).toBe(201);
+    expect(res.statusCode).toBe(200);
     expect(res._isEndCalled()).toBeTruthy();
   });
 
@@ -158,11 +158,11 @@ describe('iOSGithubLogin user Controller 테스트', () => {
     expect(res._isJSON()).toBeTruthy();
   });
 
-  it('에러가 나면 403응답이 오는가', async () => {
+  it('에러가 나면 400응답이 오는가', async () => {
     const errorMessage = { error: 'Error Message' };
     userService.iOSGithubLogin.mockReturnValue(errorMessage);
     await userController.iOSGitHubLogin(req, res);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(400);
     expect(res._isEndCalled()).toBeTruthy();
   });
 });

--- a/backend/src/controller/image.js
+++ b/backend/src/controller/image.js
@@ -2,8 +2,12 @@ const imageService = require('../service/image');
 const control = require('../lib/controller');
 
 module.exports = {
-  upload: (req, res) => {
-    const { status, result } = control(imageService.upload, req.file, 201);
+  upload: async (req, res) => {
+    const { status, result } = await control(
+      imageService.upload,
+      req.file,
+      201
+    );
 
     return res.status(status).json(result);
   },


### PR DESCRIPTION
## 상세사항
- controller로직 수정으로 인해서 변경된 상태코드 등의 테스트 코드를 수정

## 기타사항
- 대부분 상태코드만 에러가 나서 상태코드 변경해주었습니다.
- 이미지 컨트롤러 테스트가 제대로 동작을 안합니다. 자꾸 응답으로 200을 받아옵니다. 저희가 201을 넘겨주는데도 말이죠... async await때문인것 같기도 한데 확인 부탁드립니다! (때문에 이미지 컨트롤러에서도 async await처리를 해주었습니다. lib/controller에 비동기로 동작하지 않는 함수를 하나 더 만드는 것도 괜찮을 것 같습니다)