### PR TITLE
[iOS] 마일스톤 추가 화면 구성

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		F44851792549736900A84527 /* LocalIssueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44851782549736900A84527 /* LocalIssueService.swift */; };
 		F448517F2549834F00A84527 /* IssueCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F448517E2549834F00A84527 /* IssueCoordinator.swift */; };
 		F44851872549835600A84527 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44851862549835600A84527 /* Coordinator.swift */; };
+		F4B4AD5F2551902F00428C68 /* MilestoneAppendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B4AD5E2551902F00428C68 /* MilestoneAppendViewController.swift */; };
 		F4B4AD642551904700428C68 /* MilestoneAppend.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4B4AD632551904700428C68 /* MilestoneAppend.storyboard */; };
 		F4E1085D254951ED0086F453 /* IssueTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E1085C254951ED0086F453 /* IssueTableViewCell.swift */; };
 		F4EB411F25515BF1007E56E1 /* InputField.xib in Resources */ = {isa = PBXBuildFile; fileRef = F4EB411E25515BF1007E56E1 /* InputField.xib */; };
@@ -120,6 +121,7 @@
 		F448517E2549834F00A84527 /* IssueCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCoordinator.swift; sourceTree = "<group>"; };
 		F44851862549835600A84527 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		F4AF30472547D21C006D7D0A /* IssueTracker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IssueTracker.entitlements; sourceTree = "<group>"; };
+		F4B4AD5E2551902F00428C68 /* MilestoneAppendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneAppendViewController.swift; sourceTree = "<group>"; };
 		F4B4AD632551904700428C68 /* MilestoneAppend.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MilestoneAppend.storyboard; sourceTree = "<group>"; };
 		F4E1085C254951ED0086F453 /* IssueTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTableViewCell.swift; sourceTree = "<group>"; };
 		F4EB411E25515BF1007E56E1 /* InputField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InputField.xib; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 				F4012A4F255027460047CE91 /* MilestoneViewController.swift */,
 				F4012A65255028A50047CE91 /* MilestoneService.swift */,
 				F4012A6A255028AD0047CE91 /* MilestoneCacheService.swift */,
+				F4B4AD5E2551902F00428C68 /* MilestoneAppendViewController.swift */,
 			);
 			path = Milestone;
 			sourceTree = "<group>";
@@ -706,6 +709,7 @@
 				F4383EF3254946A4003FB09D /* CheckBox.swift in Sources */,
 				F4FF1AB5254FE46100635360 /* LabelNetworkService.swift in Sources */,
 				FC889ACB254ABDA300E335CF /* BarButtonController.swift in Sources */,
+				F4B4AD5F2551902F00428C68 /* MilestoneAppendViewController.swift in Sources */,
 				F4EB412425515FEC007E56E1 /* InputField.swift in Sources */,
 				F4383ED3254931C9003FB09D /* BadgeView.swift in Sources */,
 				FC78518F2548996400E60957 /* RoundButton.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		F448517F2549834F00A84527 /* IssueCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F448517E2549834F00A84527 /* IssueCoordinator.swift */; };
 		F44851872549835600A84527 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44851862549835600A84527 /* Coordinator.swift */; };
 		F4E1085D254951ED0086F453 /* IssueTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E1085C254951ED0086F453 /* IssueTableViewCell.swift */; };
+		F4EB411F25515BF1007E56E1 /* InputField.xib in Resources */ = {isa = PBXBuildFile; fileRef = F4EB411E25515BF1007E56E1 /* InputField.xib */; };
+		F4EB412425515FEC007E56E1 /* InputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EB412325515FEC007E56E1 /* InputField.swift */; };
 		F4FE9C0F254908F30054DAAD /* IssueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE9C0E254908F30054DAAD /* IssueViewController.swift */; };
 		F4FF1AB5254FE46100635360 /* LabelNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF1AB4254FE46100635360 /* LabelNetworkService.swift */; };
 		FC5CAE5F254FA1CA0086EA13 /* UserNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5CAE5E254FA1CA0086EA13 /* UserNetworkService.swift */; };
@@ -118,6 +120,8 @@
 		F44851862549835600A84527 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		F4AF30472547D21C006D7D0A /* IssueTracker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IssueTracker.entitlements; sourceTree = "<group>"; };
 		F4E1085C254951ED0086F453 /* IssueTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTableViewCell.swift; sourceTree = "<group>"; };
+		F4EB411E25515BF1007E56E1 /* InputField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InputField.xib; sourceTree = "<group>"; };
+		F4EB412325515FEC007E56E1 /* InputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputField.swift; sourceTree = "<group>"; };
 		F4FE9C0E254908F30054DAAD /* IssueViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueViewController.swift; sourceTree = "<group>"; };
 		F4FF1AB4254FE46100635360 /* LabelNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelNetworkService.swift; sourceTree = "<group>"; };
 		FC5CAE5E254FA1CA0086EA13 /* UserNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNetworkService.swift; sourceTree = "<group>"; };
@@ -226,6 +230,15 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		F40E272A2551843B00FE25D0 /* Xibs */ = {
+			isa = PBXGroup;
+			children = (
+				F4EB412325515FEC007E56E1 /* InputField.swift */,
+				F4EB411E25515BF1007E56E1 /* InputField.xib */,
+			);
+			path = Xibs;
+			sourceTree = "<group>";
+		};
 		F448517D2549833700A84527 /* Coordinators */ = {
 			isa = PBXGroup;
 			children = (
@@ -241,6 +254,7 @@
 		F4AF30422547CF26006D7D0A /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				F40E272A2551843B00FE25D0 /* Xibs */,
 				F4E10861254951F30086F453 /* Customs */,
 				FC78518D2548992900E60957 /* Designables */,
 				F4AF30432547CF2E006D7D0A /* Storyboards */,
@@ -539,6 +553,7 @@
 				F4383EC625493016003FB09D /* Issue.storyboard in Resources */,
 				F4012A4A255023F50047CE91 /* Milestone.storyboard in Resources */,
 				FCF196EE2547AED200AED031 /* Assets.xcassets in Resources */,
+				F4EB411F25515BF1007E56E1 /* InputField.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -687,6 +702,7 @@
 				F4383EF3254946A4003FB09D /* CheckBox.swift in Sources */,
 				F4FF1AB5254FE46100635360 /* LabelNetworkService.swift in Sources */,
 				FC889ACB254ABDA300E335CF /* BarButtonController.swift in Sources */,
+				F4EB412425515FEC007E56E1 /* InputField.swift in Sources */,
 				F4383ED3254931C9003FB09D /* BadgeView.swift in Sources */,
 				FC78518F2548996400E60957 /* RoundButton.swift in Sources */,
 				F448516F254971F600A84527 /* IssueService.swift in Sources */,
@@ -699,7 +715,6 @@
 				FCF197342547FAB100AED031 /* SignCoordinator.swift in Sources */,
 				FC7851A32548A13300E60957 /* GithubSignService.swift in Sources */,
 				FC631A7B254FF7A400DFE242 /* FilterViewController.swift in Sources */,
-				FC889AC3254AB17600E335CF /* Issues.swift in Sources */,
 				FC5CAE5F254FA1CA0086EA13 /* UserNetworkService.swift in Sources */,
 				F4012A50255027460047CE91 /* MilestoneViewController.swift in Sources */,
 				F448517F2549834F00A84527 /* IssueCoordinator.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		F44851792549736900A84527 /* LocalIssueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44851782549736900A84527 /* LocalIssueService.swift */; };
 		F448517F2549834F00A84527 /* IssueCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F448517E2549834F00A84527 /* IssueCoordinator.swift */; };
 		F44851872549835600A84527 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44851862549835600A84527 /* Coordinator.swift */; };
+		F4B4AD642551904700428C68 /* MilestoneAppend.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F4B4AD632551904700428C68 /* MilestoneAppend.storyboard */; };
 		F4E1085D254951ED0086F453 /* IssueTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E1085C254951ED0086F453 /* IssueTableViewCell.swift */; };
 		F4EB411F25515BF1007E56E1 /* InputField.xib in Resources */ = {isa = PBXBuildFile; fileRef = F4EB411E25515BF1007E56E1 /* InputField.xib */; };
 		F4EB412425515FEC007E56E1 /* InputField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EB412325515FEC007E56E1 /* InputField.swift */; };
@@ -119,6 +120,7 @@
 		F448517E2549834F00A84527 /* IssueCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCoordinator.swift; sourceTree = "<group>"; };
 		F44851862549835600A84527 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		F4AF30472547D21C006D7D0A /* IssueTracker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IssueTracker.entitlements; sourceTree = "<group>"; };
+		F4B4AD632551904700428C68 /* MilestoneAppend.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MilestoneAppend.storyboard; sourceTree = "<group>"; };
 		F4E1085C254951ED0086F453 /* IssueTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTableViewCell.swift; sourceTree = "<group>"; };
 		F4EB411E25515BF1007E56E1 /* InputField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InputField.xib; sourceTree = "<group>"; };
 		F4EB412325515FEC007E56E1 /* InputField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputField.swift; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 				F4383EC225493016003FB09D /* SignIn.storyboard */,
 				FC631A72254FF4B500DFE242 /* Filter.storyboard */,
 				F4012A49255023F50047CE91 /* Milestone.storyboard */,
+				F4B4AD632551904700428C68 /* MilestoneAppend.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -548,6 +551,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F4383EC525493016003FB09D /* SignIn.storyboard in Resources */,
+				F4B4AD642551904700428C68 /* MilestoneAppend.storyboard in Resources */,
 				F4383EC725493016003FB09D /* LaunchScreen.storyboard in Resources */,
 				FC631A73254FF4B500DFE242 /* Filter.storyboard in Resources */,
 				F4383EC625493016003FB09D /* Issue.storyboard in Resources */,

--- a/iOS/IssueTracker/IssueTracker/ViewControllers/Milestone/MilestoneAppendViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/ViewControllers/Milestone/MilestoneAppendViewController.swift
@@ -1,0 +1,39 @@
+//
+//  MilestoneAppendViewController.swift
+//  IssueTracker
+//
+//  Created by 현기엽 on 2020/11/03.
+//
+
+import UIKit
+
+class MilestoneAppendViewController: UIViewController {
+    @IBOutlet weak var titleInputField: InputField!
+    @IBOutlet weak var deadlineInputField: InputField!
+    @IBOutlet weak var descriptionInputField: InputField!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTitle()
+    }
+    
+    private func setupTitle() {
+        titleInputField.setTitle("제목")
+        deadlineInputField.setTitle("완료\n날짜")
+        descriptionInputField.setTitle("설명")
+    }
+    
+    @IBAction func didCloseButtonTapped(_ sender: UIButton) {
+        dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func didClearButtonTapped(_ sender: UIButton) {
+        titleInputField.clear()
+        deadlineInputField.clear()
+        descriptionInputField.clear()
+    }
+    
+    @IBAction func didSaveButtonTapped(_ sender: UIButton) {
+        //TODO
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/ViewControllers/Milestone/MilestoneCacheService.swift
+++ b/iOS/IssueTracker/IssueTracker/ViewControllers/Milestone/MilestoneCacheService.swift
@@ -21,7 +21,9 @@ class MilestoneCacheService: MilestoneService {
         return milestones[indexPath.item]
     }
     
-    var count: Int = 0
+    var count: Int {
+        return milestones.count
+    }
     
     func reloadData() {
         networkService.fetchMilestones { [weak self] result in

--- a/iOS/IssueTracker/IssueTracker/Views/Storyboards/Milestone.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Views/Storyboards/Milestone.storyboard
@@ -130,6 +130,9 @@
                                             </constraints>
                                         </collectionViewCellContentView>
                                         <size key="customSize" width="191" height="144"/>
+                                        <connections>
+                                            <segue destination="KVP-Jq-pQc" kind="presentation" id="E6M-Cw-yLL"/>
+                                        </connections>
                                     </collectionViewCell>
                                 </cells>
                                 <connections>
@@ -157,6 +160,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fr8-3Y-F27" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="40.579710144927539" y="-56.25"/>
+        </scene>
+        <!--MilestoneAppend-->
+        <scene sceneID="gNd-3b-dO5">
+            <objects>
+                <viewControllerPlaceholder storyboardName="MilestoneAppend" id="KVP-Jq-pQc" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="D7E-fP-g2t" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="790" y="-114"/>
         </scene>
     </scenes>
     <designables>

--- a/iOS/IssueTracker/IssueTracker/Views/Storyboards/MilestoneAppend.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Views/Storyboards/MilestoneAppend.storyboard
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4VG-tg-zFp">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Milestone Append View Controller-->
+        <scene sceneID="cWe-sa-4ZZ">
+            <objects>
+                <viewController id="4VG-tg-zFp" customClass="MilestoneAppendViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="SZb-SJ-IiM">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lIL-t9-IkH" customClass="BadgeView" customModule="IssueTracker" customModuleProvider="target">
+                                <rect key="frame" x="20.5" y="243.5" width="373" height="409"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W08-M7-uFl">
+                                        <rect key="frame" x="10" y="10" width="353" height="389"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="acG-9x-Ubw">
+                                                <rect key="frame" x="20" y="20" width="313" height="349"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EaO-vL-eun">
+                                                        <rect key="frame" x="0.0" y="0.0" width="313" height="30"/>
+                                                        <state key="normal" title="x"/>
+                                                        <connections>
+                                                            <action selector="didCloseButtonTapped:" destination="4VG-tg-zFp" eventType="touchUpInside" id="Ox5-0a-gN1"/>
+                                                        </connections>
+                                                    </button>
+                                                    <view contentMode="scaleToFill" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="SJk-CM-FKG">
+                                                        <rect key="frame" x="0.0" y="30" width="313" height="289"/>
+                                                        <subviews>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="quc-Zv-3RS">
+                                                                <rect key="frame" x="0.0" y="39.5" width="313" height="210"/>
+                                                                <subviews>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fbN-ZP-muz" customClass="InputField" customModule="IssueTracker" customModuleProvider="target">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="313" height="70"/>
+                                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                    </view>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dlx-Wh-gVw" customClass="InputField" customModule="IssueTracker" customModuleProvider="target">
+                                                                        <rect key="frame" x="0.0" y="70" width="313" height="70"/>
+                                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                    </view>
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LVo-7C-LsJ" customClass="InputField" customModule="IssueTracker" customModuleProvider="target">
+                                                                        <rect key="frame" x="0.0" y="140" width="313" height="70"/>
+                                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                    </view>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="210" id="9Yq-Bf-4KE"/>
+                                                                </constraints>
+                                                            </stackView>
+                                                        </subviews>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        <constraints>
+                                                            <constraint firstItem="quc-Zv-3RS" firstAttribute="leading" secondItem="SJk-CM-FKG" secondAttribute="leading" id="TWD-D5-nZj"/>
+                                                            <constraint firstAttribute="trailing" secondItem="quc-Zv-3RS" secondAttribute="trailing" id="mC5-4j-WVx"/>
+                                                            <constraint firstItem="quc-Zv-3RS" firstAttribute="centerY" secondItem="SJk-CM-FKG" secondAttribute="centerY" id="q7r-dA-bsF"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="w8Y-pq-smb">
+                                                        <rect key="frame" x="0.0" y="319" width="313" height="30"/>
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LZ1-xF-ff0">
+                                                                <rect key="frame" x="0.0" y="0.0" width="156.5" height="30"/>
+                                                                <state key="normal" title="초기화"/>
+                                                                <connections>
+                                                                    <action selector="didClearButtonTapped:" destination="4VG-tg-zFp" eventType="touchUpInside" id="jhw-Yn-LQ8"/>
+                                                                </connections>
+                                                            </button>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZXv-iK-yOO" customClass="RoundButton" customModule="IssueTracker" customModuleProvider="target">
+                                                                <rect key="frame" x="156.5" y="0.0" width="156.5" height="30"/>
+                                                                <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                                                <state key="normal" title="저장">
+                                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                </state>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                        <real key="value" value="5"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                                        <real key="value" value="1"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                                        <color key="value" systemColor="systemBlueColor"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="didSaveButtonTapped:" destination="4VG-tg-zFp" eventType="touchUpInside" id="4jg-QK-VyY"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="acG-9x-Ubw" firstAttribute="centerX" secondItem="W08-M7-uFl" secondAttribute="centerX" id="Tma-uF-kpe"/>
+                                            <constraint firstItem="acG-9x-Ubw" firstAttribute="top" secondItem="W08-M7-uFl" secondAttribute="top" constant="20" id="UwM-SL-WKE"/>
+                                            <constraint firstItem="acG-9x-Ubw" firstAttribute="width" secondItem="W08-M7-uFl" secondAttribute="width" constant="-40" id="xRv-oW-ZG1"/>
+                                            <constraint firstAttribute="bottom" secondItem="acG-9x-Ubw" secondAttribute="bottom" constant="20" id="zFH-eY-OWk"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="W08-M7-uFl" secondAttribute="bottom" constant="10" id="Ssm-Ai-5dc"/>
+                                    <constraint firstItem="W08-M7-uFl" firstAttribute="top" secondItem="lIL-t9-IkH" secondAttribute="top" constant="10" id="USb-nT-NUA"/>
+                                    <constraint firstAttribute="trailing" secondItem="W08-M7-uFl" secondAttribute="trailing" constant="10" id="f0m-XM-ibQ"/>
+                                    <constraint firstItem="W08-M7-uFl" firstAttribute="leading" secondItem="lIL-t9-IkH" secondAttribute="leading" constant="10" id="wHD-mV-KE4"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="20"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="bcS-QG-Lqt"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="lIL-t9-IkH" firstAttribute="width" secondItem="bcS-QG-Lqt" secondAttribute="width" multiplier="0.9" id="UYt-Gx-CFD"/>
+                            <constraint firstItem="lIL-t9-IkH" firstAttribute="centerY" secondItem="SZb-SJ-IiM" secondAttribute="centerY" id="kSY-jA-eOI"/>
+                            <constraint firstItem="lIL-t9-IkH" firstAttribute="height" secondItem="bcS-QG-Lqt" secondAttribute="height" multiplier="0.5" id="lxh-rR-9ne"/>
+                            <constraint firstItem="lIL-t9-IkH" firstAttribute="centerX" secondItem="SZb-SJ-IiM" secondAttribute="centerX" id="vMs-KP-bCZ"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="deadlineInputField" destination="dlx-Wh-gVw" id="YZL-Gv-xmu"/>
+                        <outlet property="descriptionInputField" destination="LVo-7C-LsJ" id="dsI-QZ-Wa0"/>
+                        <outlet property="titleInputField" destination="fbN-ZP-muz" id="zz3-gJ-nP5"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="kHx-2X-gOl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="978" y="-56"/>
+        </scene>
+    </scenes>
+    <designables>
+        <designable name="ZXv-iK-yOO">
+            <size key="intrinsicContentSize" width="30" height="30"/>
+        </designable>
+        <designable name="lIL-t9-IkH">
+            <size key="intrinsicContentSize" width="12" height="0.0"/>
+        </designable>
+    </designables>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOS/IssueTracker/IssueTracker/Views/Xibs/InputField.swift
+++ b/iOS/IssueTracker/IssueTracker/Views/Xibs/InputField.swift
@@ -1,0 +1,41 @@
+//
+//  InputField.swift
+//  IssueTracker
+//
+//  Created by 현기엽 on 2020/11/03.
+//
+
+import UIKit
+
+class InputField: UIView {
+    private let xibName = "InputField"
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var textField: UITextField!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.config()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        self.config()
+    }
+    
+    private func config(){
+        guard let view = Bundle.main.loadNibNamed(xibName, owner: self, options: nil)?.first as? UIView else {
+            return
+        }
+        
+        view.frame = self.bounds
+        self.addSubview(view)
+    }
+    
+    func clear() {
+        textField.text = ""
+    }
+    
+    func setTitle(_ title: String) {
+        titleLabel.text = title
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Views/Xibs/InputField.xib
+++ b/iOS/IssueTracker/IssueTracker/Views/Xibs/InputField.xib
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="InputField" customModule="IssueTracker" customModuleProvider="target">
+            <connections>
+                <outlet property="textField" destination="tSC-a4-aP4" id="xjc-FE-5qJ"/>
+                <outlet property="titleLabel" destination="nTA-aI-yKJ" id="XL1-QP-rHV"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="800" height="70"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ws-f3-vJD">
+                    <rect key="frame" x="40" y="35" width="720" height="1"/>
+                    <color key="backgroundColor" systemColor="systemGrayColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="IG0-79-yud"/>
+                    </constraints>
+                </view>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nTA-aI-yKJ">
+                    <rect key="frame" x="50" y="0.0" width="29.5" height="21"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tSC-a4-aP4">
+                    <rect key="frame" x="99.5" y="1" width="640.5" height="19"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="0Ws-f3-vJD" secondAttribute="bottom" id="2RH-fW-f8Y"/>
+                <constraint firstItem="0Ws-f3-vJD" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="7uc-68-kP6"/>
+                <constraint firstItem="tSC-a4-aP4" firstAttribute="trailing" secondItem="0Ws-f3-vJD" secondAttribute="trailing" constant="-20" id="HFS-Zz-7pd"/>
+                <constraint firstItem="0Ws-f3-vJD" firstAttribute="top" secondItem="tSC-a4-aP4" secondAttribute="bottom" constant="15" id="MDr-53-ToU"/>
+                <constraint firstItem="nTA-aI-yKJ" firstAttribute="centerY" secondItem="tSC-a4-aP4" secondAttribute="centerY" id="cQY-Pn-udf"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="0Ws-f3-vJD" secondAttribute="bottom" id="lh0-NP-lRe"/>
+                <constraint firstItem="0Ws-f3-vJD" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" multiplier="0.9" id="sPz-2x-0La"/>
+                <constraint firstItem="0Ws-f3-vJD" firstAttribute="leading" secondItem="nTA-aI-yKJ" secondAttribute="leading" constant="-10" id="sg6-6Y-FYm"/>
+                <constraint firstItem="nTA-aI-yKJ" firstAttribute="trailing" secondItem="tSC-a4-aP4" secondAttribute="leading" constant="-20" id="swC-DP-ICI"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="131.8840579710145" y="56.919642857142854"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
## 구현 내용 [#33]
- 마일스톤 추가 화면 구성
- InputField (레이블과 밑줄, 텍스트 필드를 포함하는 커스텀 뷰) 추가
- 마일스톤 목록을 제대로 표시하지 못하는 문제 수정
- 마일스톤 추가 뷰컨트롤러

## 기타 사항
- 세부 기능 구현하지 않음

![image](https://user-images.githubusercontent.com/16751025/97991729-29de7480-1e25-11eb-8e23-38be993e5033.png)
