### PR TITLE
[FE] ContextAPI 구현 및 유저정보 조회 및 이슈 정보 가져오기 API 구현

### DIFF
--- a/client/src/apis/issue.js
+++ b/client/src/apis/issue.js
@@ -1,0 +1,18 @@
+import request from '../lib/axios';
+
+const getListAPI = async (search) => {
+  try {
+    const {
+      data: { issues },
+    } = await request({
+      method: 'get',
+      params: `/issue?q=${search}`,
+    });
+
+    return { issues };
+  } catch (error) {
+    return false;
+  }
+};
+
+export default getListAPI;

--- a/client/src/apis/user.js
+++ b/client/src/apis/user.js
@@ -27,3 +27,14 @@ export const getUserAPI = async () => {
     return false;
   }
 };
+
+export const getUsersAPI = async () => {
+  try {
+    const {
+      data: { assignee },
+    } = await request({ method: 'get', params: '/user/users' });
+    return { assignee };
+  } catch (error) {
+    return false;
+  }
+};

--- a/client/src/components/IssueItem/index.jsx
+++ b/client/src/components/IssueItem/index.jsx
@@ -38,11 +38,11 @@ const Issues = ({ issue }) => {
           <Id>#{issue.id}</Id>
           <Text>
             {issue.is_opened
-              ? `opened yesterday by qkrdmstlr3`
-              : `closed by qkrdmstlr3 yesterday`}
+              ? `opened yesterday by ${issue.User.name}`
+              : `closed by ${issue.User.name} yesterday`}
           </Text>
           <FontAwesomeIcon icon={faFlag} />
-          <Milestone>{issue.Milestone.title}</Milestone>
+          <Milestone>{issue.Milestone ? issue.Milestone.title : ''}</Milestone>
         </Bottom>
       </Issue>
       <Assignees>

--- a/client/src/components/IssueList/index.jsx
+++ b/client/src/components/IssueList/index.jsx
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 import IssueItem from '../IssueItem';
-import dummy from './dummy';
 
 import { List } from './styled';
+import { IssueContext } from '../../stores/issueStore';
 
 const IssueList = () => {
+  const {
+    issueState: { list },
+    issueAction: { getList },
+  } = useContext(IssueContext);
+  useEffect(async () => {
+    await getList('is:open');
+  }, []);
   return (
     <List>
-      {dummy.map((issue, index) => (
+      {list.map((issue, index) => (
         <IssueItem issue={issue} key={index} />
       ))}
     </List>

--- a/client/src/components/ListHeader/index.jsx
+++ b/client/src/components/ListHeader/index.jsx
@@ -1,0 +1,40 @@
+/* eslint-disable react/self-closing-comp */
+
+import React from 'react';
+import { Div, Details } from './styled';
+import SelectMenu from '../SelectMenu';
+
+const ListHeader = () => {
+  return (
+    <Div width="60%" margin="0 auto" border="1px solid lightGray">
+      <Div padding="10px">
+        <input type="checkbox"></input>
+      </Div>
+      <Div width="100%">
+        <Div padding="10px"> close/open</Div>
+        <Div width="100%" align="flex-end">
+          <Details>
+            <summary>Assignee</summary>
+            <Div position="absolute">
+              <SelectMenu />
+            </Div>
+          </Details>
+          <Details>
+            <summary>Assignee</summary>
+            <Div position="absolute">
+              <SelectMenu />
+            </Div>
+          </Details>
+          <Details>
+            <summary>Assignee</summary>
+            <Div position="absolute">
+              <SelectMenu />
+            </Div>
+          </Details>
+        </Div>
+      </Div>
+    </Div>
+  );
+};
+
+export default ListHeader;

--- a/client/src/components/ListHeader/index.jsx
+++ b/client/src/components/ListHeader/index.jsx
@@ -1,10 +1,14 @@
 /* eslint-disable react/self-closing-comp */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import { Div, Details } from './styled';
 import SelectMenu from '../SelectMenu';
+import { UsersContext } from '../../stores/usersStore';
 
 const ListHeader = () => {
+  const {
+    usersAction: { getUsers },
+  } = useContext(UsersContext);
   return (
     <Div width="60%" margin="0 auto" border="1px solid lightGray">
       <Div padding="10px">
@@ -13,22 +17,14 @@ const ListHeader = () => {
       <Div width="100%">
         <Div padding="10px"> close/open</Div>
         <Div width="100%" align="flex-end">
-          <Details>
+          <Details
+            onClick={() => {
+              getUsers();
+            }}
+          >
             <summary>Assignee</summary>
             <Div position="absolute">
-              <SelectMenu />
-            </Div>
-          </Details>
-          <Details>
-            <summary>Assignee</summary>
-            <Div position="absolute">
-              <SelectMenu />
-            </Div>
-          </Details>
-          <Details>
-            <summary>Assignee</summary>
-            <Div position="absolute">
-              <SelectMenu />
+              <SelectMenu title="author" />
             </Div>
           </Details>
         </Div>

--- a/client/src/components/ListHeader/styled.js
+++ b/client/src/components/ListHeader/styled.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const Div = styled.div`
+  position: ${(props) => props.position};
+  display: flex;
+  width: ${(props) => props.width};
+  margin: ${(props) => props.margin};
+  justify-content: ${(props) => props.align};
+  padding: ${(props) => props.padding};
+  border: ${(props) => props.border};
+`;
+const Details = styled.details`
+  padding: 10px;
+`;
+export { Div, Details };

--- a/client/src/components/SelectMenu/index.jsx
+++ b/client/src/components/SelectMenu/index.jsx
@@ -1,0 +1,64 @@
+/* eslint-disable react/self-closing-comp */
+
+import React from 'react';
+import { ListItem, Modal, Title, Image, Name, Div } from './styled';
+
+const SelectMenu = () => {
+  const title = 'author';
+  const test = [
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+    {
+      name: 'joojaewoo',
+      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
+    },
+  ];
+  return (
+    <Modal>
+      <Div>
+        <Title>{title}</Title>
+      </Div>
+      <Div />
+      <Div>
+        {test.map((item) => (
+          <ListItem>
+            <Image width="20px" height="20px" src={item.image} />
+            <Name>{item.name}</Name>
+          </ListItem>
+        ))}
+      </Div>
+    </Modal>
+  );
+};
+
+export default SelectMenu;

--- a/client/src/components/SelectMenu/index.jsx
+++ b/client/src/components/SelectMenu/index.jsx
@@ -1,57 +1,25 @@
 /* eslint-disable react/self-closing-comp */
 
-import React from 'react';
+import React, { useContext } from 'react';
+import { IssueContext } from '../../stores/issueStore';
+import { UsersContext } from '../../stores/usersStore';
 import { ListItem, Modal, Title, Image, Name, Div } from './styled';
 
 const SelectMenu = () => {
-  const title = 'author';
-  const test = [
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-    {
-      name: 'joojaewoo',
-      image: 'https://avatars2.githubusercontent.com/u/46195613?v=4',
-    },
-  ];
+  const {
+    usersState: { users },
+  } = useContext(UsersContext);
+  const {
+    issueAction: { getList },
+  } = useContext(IssueContext);
   return (
     <Modal>
       <Div>
-        <Title>{title}</Title>
+        <Title>author</Title>
       </Div>
-      <Div />
       <Div>
-        {test.map((item) => (
-          <ListItem>
+        {users.map((item, index) => (
+          <ListItem onClick={() => getList(`author:${item.name}`)} key={index}>
             <Image width="20px" height="20px" src={item.image} />
             <Name>{item.name}</Name>
           </ListItem>

--- a/client/src/components/SelectMenu/styled.js
+++ b/client/src/components/SelectMenu/styled.js
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+const Modal = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  display: flex;
+  padding: 16px;
+  width: 200px;
+  height: 400px;
+  flex-direction: column;
+  background: #ffffff;
+  overflow: auto;
+`;
+
+const Div = styled.div`
+  margin: 0 20px;
+  font-size: 30px;
+  font-weight: bold;
+  text-align: center;
+`;
+
+const Title = styled.span`
+  flex: 1;
+  font-size: 20px;
+  margin: 0 auto;
+  font-weight: 600;
+`;
+const CloseButton = styled.span``;
+
+const ListItem = styled.a`
+  display: flex;
+  padding: 10px;
+  margin: 5px;
+  justify-content: space-around;
+`;
+
+const Name = styled.div`
+  font-size: 10px;
+  margin: auto;
+`;
+const Image = styled.img.attrs({
+  alt: 'github-icon',
+})`
+  border-radius: 10px;
+  display: block;
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+`;
+export { Div, Modal, Title, CloseButton, ListItem, Image, Name };

--- a/client/src/components/SelectMenu/styled.js
+++ b/client/src/components/SelectMenu/styled.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const Modal = styled.div`
-  position: fixed;
+  position: relative;
   top: 0;
   right: 0;
   bottom: 0;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -8,14 +8,20 @@ import GlobalStyle from './style/global-style';
 import App from './App';
 
 import { UserProvider } from './stores/userStore';
+import { IssueProvider } from './stores/issueStore';
+import { UsersProvider } from './stores/usersStore';
 
 ReactDom.render(
   <BrowserRouter>
     <UserProvider>
-      <ThemeProvider theme={theme}>
-        <GlobalStyle />
-        <App />
-      </ThemeProvider>
+      <IssueProvider>
+        <UsersProvider>
+          <ThemeProvider theme={theme}>
+            <GlobalStyle />
+            <App />
+          </ThemeProvider>
+        </UsersProvider>
+      </IssueProvider>
     </UserProvider>
   </BrowserRouter>,
   document.getElementById('root')

--- a/client/src/lib/PrivateRoute.jsx
+++ b/client/src/lib/PrivateRoute.jsx
@@ -2,20 +2,23 @@
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/prop-types */
 import React, { useContext, useEffect } from 'react';
-import { Route } from 'react-router-dom';
+import { Route, Redirect } from 'react-router-dom';
 import { UserContext } from '../stores/userStore';
 
 const PrivateRoute = ({ component: Component, ...rest }) => {
   const {
-    userState: { name },
+    userState: { name, update },
     userAction: { getUser },
   } = useContext(UserContext);
-
   useEffect(async () => {
     await getUser();
   }, []);
+
   if (name) {
     return <Route {...rest} render={(props) => <Component {...props} />} />;
+  }
+  if (update && !name) {
+    return <Redirect to="/login" />;
   }
   return <div>hello</div>;
 };

--- a/client/src/pages/Callback/index.jsx
+++ b/client/src/pages/Callback/index.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useContext } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import qs from 'qs';
 import { UserContext } from '../../stores/userStore';
+import Image from './styled';
 
 const Callback = ({ history, location }) => {
   const {
@@ -17,7 +18,7 @@ const Callback = ({ history, location }) => {
     return history.push('/');
   }, []);
 
-  return <div>hello</div>;
+  return <Image />;
 };
 
 export default Callback;

--- a/client/src/pages/Callback/styled.js
+++ b/client/src/pages/Callback/styled.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const Image = styled.img.attrs({
+  src:
+    'https://raw.githubusercontent.com/qkrdmstlr3/svg-icon-animation/master/react-icon/react-icon.gif',
+  alt: 'github-icon',
+})`
+  border-radius: 10px;
+  display: block;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+`;
+
+export default Image;

--- a/client/src/pages/Issues/index.jsx
+++ b/client/src/pages/Issues/index.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import IssueList from '../../components/IssueList';
+import ListHeader from '../../components/ListHeader';
 
 const Issues = () => {
   return (
     <div>
+      <ListHeader />
       <IssueList />
     </div>
   );

--- a/client/src/stores/issueStore.js
+++ b/client/src/stores/issueStore.js
@@ -1,0 +1,53 @@
+import React, { createContext, useReducer } from 'react';
+import PropTypes from 'prop-types';
+import getListAPI from '../apis/issue';
+
+const initialState = {
+  search: undefined,
+  list: [],
+};
+
+export const GET_LIST = 'GET_LIST';
+
+const IssueReducer = (state, action) => {
+  switch (action.type) {
+    case GET_LIST: {
+      if (action.issues && action.search) {
+        return {
+          search: action.search,
+          list: action.issues,
+        };
+      }
+      return state;
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+const IssueContext = createContext();
+
+const IssueProvider = ({ children }) => {
+  const [issueState, dispatch] = useReducer(IssueReducer, initialState);
+
+  const issueAction = {
+    getList: async (search) => {
+      const { issues } = await getListAPI(search);
+      dispatch({ type: GET_LIST, issues, search });
+    },
+  };
+
+  return (
+    // eslint-disable-next-line react/jsx-filename-extension
+    <IssueContext.Provider value={{ issueState, issueAction }}>
+      {children}
+    </IssueContext.Provider>
+  );
+};
+
+IssueProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export { IssueContext, IssueProvider };

--- a/client/src/stores/userStore.js
+++ b/client/src/stores/userStore.js
@@ -5,6 +5,7 @@ import { loginAPI, getUserAPI } from '../apis/user';
 const initialState = {
   name: undefined,
   image: undefined,
+  update: false,
 };
 
 export const LOGIN_USER = 'LOGIN_USER';
@@ -19,6 +20,7 @@ const userReducer = (state, action) => {
         return {
           name: action.result.name,
           image: action.result.image,
+          update: false,
         };
       }
       return state;
@@ -28,11 +30,12 @@ const userReducer = (state, action) => {
     }
     case GET_USER: {
       if (!action.result) {
-        return state;
+        return { update: true };
       }
       return {
         name: action.result.name,
         image: action.result.image,
+        update: true,
       };
     }
     default: {

--- a/client/src/stores/usersStore.js
+++ b/client/src/stores/usersStore.js
@@ -1,0 +1,52 @@
+import React, { createContext, useReducer } from 'react';
+import PropTypes from 'prop-types';
+import { getUsersAPI } from '../apis/user';
+
+const initialState = {
+  users: [],
+  update: false,
+};
+
+export const GET_USERS = 'GET_USERS';
+
+const usersReducer = (state, action) => {
+  switch (action.type) {
+    case GET_USERS: {
+      return {
+        update: true,
+        users: action.result,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+const UsersContext = createContext();
+
+const UsersProvider = ({ children }) => {
+  const [usersState, dispatch] = useReducer(usersReducer, initialState);
+
+  const usersAction = {
+    getUsers: async () => {
+      if (!usersState.update) {
+        const result = await getUsersAPI();
+        dispatch({ type: GET_USERS, result: result.assignee });
+      }
+    },
+  };
+
+  return (
+    // eslint-disable-next-line react/jsx-filename-extension
+    <UsersContext.Provider value={{ usersState, usersAction }}>
+      {children}
+    </UsersContext.Provider>
+  );
+};
+
+UsersProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export { UsersContext, UsersProvider };


### PR DESCRIPTION
## 구현내용
- issue, users store를 ContextAPI로 구현
- 유저들 정보, 이슈들 정보 가져오기 API axios로 구현
- 리스트 컴포넌트에 더미데이터 대신 가져온 데이터로 화면 렌더링 
- 상태가 변할때 rerendering

## 기타 사항
- ContextAPI를 사용하려면 각 드롭다운 메뉴마다 컴포넌트를 만들어야 될 것 같습니다. (하나로 쓰려면 분기문이 많이 필요할 것 같습니다.)
- 만약 각 드롭다운 메뉴마다 컴포넌트를 만든다면 현재 MenuList 컴포넌트는 assignee와 author 필터링 드롭다운 메뉴로 사용하면 될 것 같습니다.
- 검색시 각 필터당 하나만 선택할 수 있기 때문에 issue store의 search 탭의 정보를 받아와 검색어 안에 각 요소가 있는지 판단하고 없으면 search 뒤에 붙이고 있으면 각 요소의 값을 현재 클릭된 요소의 값으로 바꿔주는 함수가 하나 필요할 것 같습니다.