### PR TITLE
[Fe] issueDetail페이지의 모달에 검색기능 추가

### DIFF
--- a/client/src/apis/issue.js
+++ b/client/src/apis/issue.js
@@ -28,13 +28,12 @@ const getIssueByIdAPI = async (id) => {
   }
 };
 
-const updateState = async (checked, state) => {
+const updateState = async (id, state) => {
   try {
     await request({
       method: 'put',
-      params: '/issue/state',
+      params: `/issue/state/${id}`,
       data: {
-        id: checked,
         isOpened: state,
       },
     });

--- a/client/src/components/DropdownItem/index.jsx
+++ b/client/src/components/DropdownItem/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Modal,
   Title,
@@ -7,17 +7,38 @@ import {
   Name,
   Image,
   Color,
+  Input,
 } from './styled';
 
 const DropdownItem = ({ title, data, changeState, serverData }) => {
   const clickHandler = (item) => {
     changeState(item);
   };
+  const [inputValue, setInputValue] = useState('');
+
+  const checkItem = (item) => {
+    if (
+      (item.title && item.title.includes(inputValue)) ||
+      (item.name && item.name.includes(inputValue)) ||
+      inputValue === ''
+    ) {
+      return true;
+    }
+    return false;
+  };
 
   return (
     <Modal>
       <Title>{title}</Title>
+      <Input
+        placeholder={`Filter ${title}`}
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+      />
       {data?.map((item, index) => {
+        if (!checkItem(item)) {
+          return null;
+        }
         return (
           <ListItem key={index} onClick={() => clickHandler(item)}>
             {item.image === '' ? (

--- a/client/src/components/DropdownItem/styled.js
+++ b/client/src/components/DropdownItem/styled.js
@@ -52,3 +52,8 @@ export const Image = styled.div`
   width: 20px;
   height: 20px;
 `;
+
+export const Input = styled.input`
+  margin: 0 auto;
+  width: 90%;
+`;

--- a/client/src/components/MarkAs/index.jsx
+++ b/client/src/components/MarkAs/index.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { Div, ListItem, Name, Modal } from './styled';
-import updateState from '../../apis/issue';
+import { updateState } from '../../apis/issue';
 import { IssueContext } from '../../stores/issueStore';
 
 const MarkAs = ({ checked, checkHandler }) => {


### PR DESCRIPTION
## 상세사항
- issueDetail페이지의 sidebar의 각 모달에 검색기능을 추가함

## 기타사항
이슈 상세페이지에서 라벨추가후 헤더를 눌러서 메인으로 가면 수정안되있는 현상이 있습니다. 
메인으로 갈 때 이슈정보들을 다시 가져와야 할 것 같습니다.