### PR TITLE
[FE] 마일스톤 리스트 페이지 구현 및 CSS 수정

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,7 +12,7 @@ import {
   Labels,
 } from './pages';
 import Layout from './components/Layout';
-import Overlay from './components/Overlay';
+import { Overlay } from './components/Overlay';
 import PrivateRoute from './lib/PrivateRoute';
 
 const App = () => {

--- a/client/src/components/Dropdown/index.jsx
+++ b/client/src/components/Dropdown/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Details, Div, Summary } from './styled';
-
+import { overlayElement } from '../Overlay';
 import SelectMenu from '../SelectMenu';
 import DropdownItem from '../DropdownItem';
 
@@ -16,13 +16,11 @@ const Dropdown = ({ title, action, changeState = null, serverData = null }) => {
     }
   };
 
-  const overlay = document.getElementById('overlay');
-
   return (
     <Details onClick={clickHandler}>
       <Summary
         onClick={() => {
-          overlay.hidden = false;
+          overlayElement.current.hidden = false;
         }}
       >
         {title}

--- a/client/src/components/Dropdown/styled.js
+++ b/client/src/components/Dropdown/styled.js
@@ -19,6 +19,7 @@ const Details = styled.details`
 
 const Summary = styled.summary`
   outline: none;
+  cursor: pointer;
 `;
 
 export { Div, Details, Summary };

--- a/client/src/components/Layout/styled.js
+++ b/client/src/components/Layout/styled.js
@@ -14,4 +14,5 @@ export const Issue = styled.h1`
   color: ${(props) => props.theme.whiteColor};
   font-size: 30px;
   font-weight: bold;
+  cursor: pointer;
 `;

--- a/client/src/components/Overlay/index.jsx
+++ b/client/src/components/Overlay/index.jsx
@@ -1,21 +1,19 @@
 /* eslint-disable no-unused-vars */
-import React, { useEffect } from 'react';
+import React, { createRef } from 'react';
 
 import Div from './styled';
 
-const Overlay = () => {
-  useEffect(() => {
-    const overlay = document.getElementById('overlay');
-    overlay.addEventListener('click', () => {
-      const details = Object.entries(document.getElementsByTagName('details'));
-      details.forEach(([_, detail]) => {
-        detail.toggleAttribute('open', false);
-      });
-      overlay.hidden = true;
-    });
-  }, []);
+const overlayElement = createRef();
 
-  return <Div />;
+const Overlay = () => {
+  const clickHandler = (e) => {
+    const details = Object.entries(document.getElementsByTagName('details'));
+    details.forEach(([_, detail]) => {
+      detail.toggleAttribute('open', false);
+    });
+    e.target.hidden = true;
+  };
+  return <Div onClick={(e) => clickHandler(e)} ref={overlayElement} />;
 };
 
-export default Overlay;
+export { Overlay, overlayElement };

--- a/client/src/pages/Issues/ListHeader/styled.js
+++ b/client/src/pages/Issues/ListHeader/styled.js
@@ -35,7 +35,6 @@ const IssueMark = styled.div`
 const Container = styled.div`
   width: 60%;
   margin: 0 auto;
-  margin-top: 30px;
   border: 1px solid lightGray;
   display: flex;
   align-items: center;

--- a/client/src/pages/Issues/ResetFilter/styled.js
+++ b/client/src/pages/Issues/ResetFilter/styled.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   width: 60%;
-  margin: 0 auto;
+  margin: 10px auto;
 `;
 const CloseMark = styled.div`
   width: 17px;

--- a/client/src/pages/Issues/SearchBox/index.jsx
+++ b/client/src/pages/Issues/SearchBox/index.jsx
@@ -13,10 +13,12 @@ import {
   DropdownItem,
   Dropdown,
   Form,
+  Summary,
 } from './styled';
 import makeSearch from '../../../lib/make-search';
 import { IssueContext } from '../../../stores/issueStore';
 import { UserContext } from '../../../stores/userStore';
+import { overlayElement } from '../../../components/Overlay';
 
 const SearchBox = () => {
   const {
@@ -49,7 +51,13 @@ const SearchBox = () => {
     <Container>
       <SearchContainer>
         <FilterBox>
-          <summary>Filters</summary>
+          <Summary
+            onClick={() => {
+              overlayElement.current.hidden = false;
+            }}
+          >
+            Filters
+          </Summary>
           <Dropdown>
             {dropdown.map((item, index) => (
               <DropdownItem key={index}>

--- a/client/src/pages/Issues/SearchBox/styled.js
+++ b/client/src/pages/Issues/SearchBox/styled.js
@@ -87,3 +87,8 @@ export const Dropdown = styled.div`
   border: 1px solid black;
   border-radius: 5px;
 `;
+
+export const Summary = styled.summary`
+  outline: none;
+  cursor: pointer;
+`;

--- a/client/src/pages/Milestones/MilestoneItem/index.jsx
+++ b/client/src/pages/Milestones/MilestoneItem/index.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { faCalendar } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Container, Status, Div, Title, Span, PointSpan } from './styled';
+
+const MilestoneItem = ({ milestone, state, updateEvent, deleteEvent }) => {
+  if (milestone?.is_opened !== state) {
+    return null;
+  }
+
+  return (
+    <Container>
+      <Div width="50%">
+        <Title>{milestone.title}</Title>
+        <Div>
+          <FontAwesomeIcon icon={faCalendar} />
+          <Span padding="0 5px">Due by {milestone.deadline}</Span>
+        </Div>
+        <Div>{milestone.content}</Div>
+      </Div>
+      <Div width="50%">
+        <Div>
+          <Status
+            percentage={Math.ceil(
+              (1 - milestone.openCount / milestone.totalCount) * 100
+            )}
+          />
+        </Div>
+        <Div>
+          <Span>
+            {milestone.totalCount !== 0
+              ? Math.ceil(
+                  (1 - milestone.openCount / milestone.totalCount) * 100
+                )
+              : 100}
+            % complete
+          </Span>
+          <Span padding="0 10px">{milestone.openCount} open</Span>
+          <Span>{milestone.totalCount - milestone.openCount} close</Span>
+        </Div>
+        <Div>
+          <PointSpan color="blue">Edit</PointSpan>
+          <PointSpan
+            color="blue"
+            padding="0 10px"
+            onClick={() => updateEvent(milestone.id, !milestone.is_opened)}
+          >
+            {state ? 'Close' : 'Open'}
+          </PointSpan>
+          <PointSpan color="red" onClick={() => deleteEvent(milestone.id)}>
+            Delete
+          </PointSpan>
+        </Div>
+      </Div>
+    </Container>
+  );
+};
+
+export default MilestoneItem;

--- a/client/src/pages/Milestones/MilestoneItem/styled.js
+++ b/client/src/pages/Milestones/MilestoneItem/styled.js
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  border-bottom: 1px solid #dddddd;
+`;
+
+const Status = styled.div`
+  width: ${(props) => props.percentage}%;
+  height: 10px;
+  border-radius: 4px;
+  background-color: green;
+`;
+
+const Div = styled.div`
+  width: ${(props) => props.width};
+  padding: 5px;
+`;
+
+const Title = styled.div`
+  font-size: 30px;
+  padding: 5px;
+`;
+
+const Span = styled.span`
+  color: ${(props) => props.color};
+  padding: ${(props) => props.padding};
+`;
+
+const PointSpan = styled.span`
+  color: ${(props) => props.color};
+  padding: ${(props) => props.padding};
+  cursor: pointer;
+`;
+
+export { Container, Status, Div, Title, Span, PointSpan };

--- a/client/src/pages/Milestones/MilestoneList/index.jsx
+++ b/client/src/pages/Milestones/MilestoneList/index.jsx
@@ -1,0 +1,62 @@
+/* eslint-disable no-param-reassign */
+import React, { useState, useEffect } from 'react';
+import { Container } from './styled';
+import MilestoneListHeader from '../MilestoneListHeader';
+import MilestoneItem from '../MilestoneItem';
+import {
+  getMilestonesAPI,
+  updateMilestoneStateAPI,
+  removeMilestoneAPI,
+} from '../../../apis/milestone';
+
+const MilestoneList = () => {
+  const [milestoneList, setMilestoneList] = useState([]);
+  const [state, setState] = useState(true);
+
+  useEffect(async () => {
+    const result = await getMilestonesAPI();
+    setMilestoneList(result);
+  }, []);
+
+  const updateStateHandler = async (id, newState) => {
+    const result = await updateMilestoneStateAPI(id, newState);
+    if (result) {
+      const newList = milestoneList.map((item) => {
+        if (item.id === id) {
+          item.is_opened = newState;
+        }
+        return item;
+      });
+      setMilestoneList(newList);
+    }
+  };
+
+  const deleteHandler = async (id) => {
+    const result = await removeMilestoneAPI(id);
+    if (result) {
+      const newList = milestoneList.filter((item) => item.id !== id);
+      setMilestoneList(newList);
+    }
+  };
+
+  return (
+    <Container>
+      <MilestoneListHeader
+        action={setState}
+        list={milestoneList}
+        state={state}
+      />
+      {milestoneList?.map((item, index) => (
+        <MilestoneItem
+          milestone={item}
+          key={index}
+          state={state}
+          updateEvent={updateStateHandler}
+          deleteEvent={deleteHandler}
+        />
+      ))}
+    </Container>
+  );
+};
+
+export default MilestoneList;

--- a/client/src/pages/Milestones/MilestoneList/styled.js
+++ b/client/src/pages/Milestones/MilestoneList/styled.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  width: 60%;
+  margin: 0 auto;
+  border: 1px solid #dddddd;
+  margin-top: 30px;
+  border-radius: 3px;
+`;
+
+const Header = styled.div`
+  border-bottom: 1px solid #dddddd;
+  padding: 10px;
+`;
+
+export { Container, Header };

--- a/client/src/pages/Milestones/MilestoneListHeader/index.jsx
+++ b/client/src/pages/Milestones/MilestoneListHeader/index.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { faCheck, faFlag } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Div, Container } from './styled';
+
+const MilestoneListHeader = ({ action, list, state }) => {
+  const close = list.filter((item) => item.is_opened === false);
+
+  return (
+    <Container>
+      <Div margin="0 10px 0 0" onClick={() => action(true)}>
+        <FontAwesomeIcon icon={faFlag} />
+        <Div margin="0 0 0 7px" state={state === true}>
+          {list.length - close.length} OPEN
+        </Div>
+      </Div>
+      <Div onClick={() => action(false)}>
+        <FontAwesomeIcon icon={faCheck} size="1x" color="gray" />
+        <Div margin="0 0 0 7px" state={state === false}>
+          {close.length} CLOSE
+        </Div>
+      </Div>
+    </Container>
+  );
+};
+
+export default MilestoneListHeader;

--- a/client/src/pages/Milestones/MilestoneListHeader/styled.js
+++ b/client/src/pages/Milestones/MilestoneListHeader/styled.js
@@ -1,0 +1,23 @@
+// eslint-disable-import/prefer-default-export
+import styled from 'styled-components';
+
+const Div = styled.div`
+  position: ${(props) => props.position};
+  display: flex;
+  width: ${(props) => props.width};
+  margin: ${(props) => props.margin};
+  justify-content: ${(props) => props.align};
+  padding: ${(props) => props.padding};
+  border: ${(props) => props.border};
+  font-weight: ${(props) => (props.state === true ? 'bolder' : '')};
+  cursor: pointer;
+`;
+
+const Container = styled.div`
+  border-bottom: solid 1px #dddddd;
+  padding: 15px 10px;
+  display: flex;
+  background-color: #f3f3f3;
+`;
+
+export { Div, Container };

--- a/client/src/pages/Milestones/index.jsx
+++ b/client/src/pages/Milestones/index.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import LabelMileNavForm from '../../components/LabelMileNavForm'
+import LabelMileNavForm from '../../components/LabelMileNavForm';
+import MilestoneList from './MilestoneList';
 
 const Milestones = () => {
   return (
     <>
       <LabelMileNavForm title="Milestone" />
+      <MilestoneList />
     </>
   );
 };


### PR DESCRIPTION
## 구현 내용
- 마일스톤 리스트 헤더 및 마일스톤 아이템 컴포넌트 구현
- useState를 사용해 client side rendering 구현
- overlay 컴포넌트에 ref등록후 export 하여 `Dropdown` 과 `SearchForm` 에서 overlay컴포넌트 hidden값을 조절
- 클릭이 필요한 곳에 pointer로 css 설정
- resetFilter 간격조절

## 스크린샷

### 마일스톤

![milestone](https://user-images.githubusercontent.com/46195613/98819923-d3021c00-2470-11eb-9e72-c984781dda72.PNG)

### 이슈 목록 간격 조절

![이슈 목록 간격 조절](https://user-images.githubusercontent.com/46195613/98820574-ac90b080-2471-11eb-9996-3e96679d0c2f.PNG)


 